### PR TITLE
fix: CTE should not implicitly be added to SELECT builder's tables

### DIFF
--- a/cte_test.go
+++ b/cte_test.go
@@ -18,7 +18,7 @@ func ExampleWith() {
 		CTETable("devices").As(
 			Select("device_id").From("devices"),
 		),
-	).Select("users.id", "orders.id", "devices.device_id").Join(
+	).Select("users.id", "orders.id", "devices.device_id").From("users", "devices").Join(
 		"orders",
 		"users.id = orders.user_id",
 		"devices.device_id = orders.device_id",
@@ -63,7 +63,7 @@ func ExampleCTEBuilder() {
 	fmt.Println(cteb)
 
 	sb := Select("valid_users.id", "valid_users.name", "orders.id").
-		From("users").With(cteb).
+		From("users", "valid_users").With(cteb).
 		Join("orders", "users.id = orders.user_id")
 	sb.Where(
 		sb.LessEqualThan("orders.price", 200),

--- a/select.go
+++ b/select.go
@@ -103,7 +103,6 @@ func (sb *SelectBuilder) TableNames() []string {
 func (sb *SelectBuilder) With(builder *CTEBuilder) *SelectBuilder {
 	sb.marker = selectMarkerAfterWith
 	sb.cteBuilder = sb.Var(builder)
-	sb.tables = append(sb.tables, builder.TableNames()...)
 	return sb
 }
 


### PR DESCRIPTION
This change reverts the implicit addition of the CTE name to the list of tables in the select builder's `FROM` clause. This allows the user to control how the CTE is joined with the other tables.